### PR TITLE
lvm2: enable LVM cache feature; bump build number

### DIFF
--- a/lvm2/lvm2.SlackBuild
+++ b/lvm2/lvm2.SlackBuild
@@ -57,7 +57,7 @@ else
   SLKTARGET=${SLKTARGET:-i486}
 fi
 SLKDTARGET=${SLKDTARGET:-slackware}
-BUILD=${BUILD:-1}
+BUILD=${BUILD:-2}
 NJOBS=${NJOBS:-$(( $(getconf _NPROCESSORS_ONLN) + 1 ))}
 DOCDIR=${PKG}/usr/doc/${NAME}-${VERSION}
 SBDIR=${PKG}/usr/src/slackbuilds/${NAME}
@@ -161,6 +161,7 @@ CXXFLAGS="${SLKCFLAGS}" \
   --enable-applib \
   --enable-cmdlib \
   --enable-lvmetad \
+  --with-cache=internal \
   --with-tmpfilesdir=/usr/lib/tmpfiles.d \
   ${SB_SYSTEMDOPTS} \
   --build=${SLKTARGET}-${SLKDTARGET}-linux || exit 1


### PR DESCRIPTION
This is needed if you want to enable SSD caching for your LVM volumes.
